### PR TITLE
feat: add git-town skill for Claude Code

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,10 @@
       url = "git+ssh://git@github.com/omerxx/tmux-sessionx.git?ref=main";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    claude-skills-bendrucker = {
+      url = "github:bendrucker/claude/1db049f4b21063bb7e18448851150fea5c98cd0e";
+      flake = false;
+    };
     darwin = {
       url = "git+ssh://git@github.com/LnL7/nix-darwin.git?shallow=1&ref=nix-darwin-25.05";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/home-manager/programs/claude-code.nix
+++ b/home-manager/programs/claude-code.nix
@@ -1,0 +1,5 @@
+{ inputs, ... }:
+{
+  home.file.".claude/skills/git-town".source =
+    "${inputs.claude-skills-bendrucker}/plugins/git-town/skills/git-town";
+}


### PR DESCRIPTION
## Summary
- Adds `bendrucker/claude` as a non-flake input (pinned to `1db049f4`)
- Creates `home-manager/programs/claude-code.nix` that symlinks the git-town skill into `~/.claude/skills/git-town`
- Other manually-managed skills in `~/.claude/skills/` are unaffected

## Test plan
- [x] `nix eval` confirms the skill source path resolves correctly
- [ ] `nix run .#home-manager-switch` applies without conflict with existing skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)