### PR TITLE
fix: use recursive symlinks for claude git-town skill

### DIFF
--- a/home-manager/programs/claude-code.nix
+++ b/home-manager/programs/claude-code.nix
@@ -1,5 +1,7 @@
 { inputs, ... }:
 {
-  home.file.".claude/skills/git-town".source =
-    "${inputs.claude-skills-bendrucker}/plugins/git-town/skills/git-town";
+  home.file.".claude/skills/git-town" = {
+    source = "${inputs.claude-skills-bendrucker}/plugins/git-town/skills/git-town";
+    recursive = true;
+  };
 }


### PR DESCRIPTION
## Summary
- Claude Code doesn't follow directory symlinks when discovering skills
- `recursive = true` makes Home Manager create a real directory with individual file symlinks inside, which Claude Code can traverse

## Test plan
- [ ] `nix run .#home-manager-switch` and verify `ls -la ~/.claude/skills/git-town/` shows a real directory with symlinked files
- [ ] `/skills` in Claude Code shows `git-town`

🤖 Generated with [Claude Code](https://claude.com/claude-code)