### PR TITLE
fix: use per-file symlinks for claude git-town skill

### DIFF
--- a/home-manager/programs/claude-code.nix
+++ b/home-manager/programs/claude-code.nix
@@ -1,5 +1,20 @@
-{ inputs, ... }:
+{ inputs, lib, ... }:
+let
+  skillSrc = "${inputs.claude-skills-bendrucker}/plugins/git-town/skills/git-town";
+  mkSkillFiles = dir: prefix:
+    let
+      entries = builtins.readDir dir;
+    in
+    lib.concatMapAttrs (
+      name: type:
+      if type == "regular" then
+        { "${prefix}/${name}".source = "${dir}/${name}"; }
+      else if type == "directory" then
+        mkSkillFiles "${dir}/${name}" "${prefix}/${name}"
+      else
+        { }
+    ) entries;
+in
 {
-  home.file.".claude/skills/git-town".source =
-    "${inputs.claude-skills-bendrucker}/plugins/git-town/skills/git-town";
+  home.file = mkSkillFiles skillSrc ".claude/skills/git-town";
 }

--- a/home-manager/programs/claude-code.nix
+++ b/home-manager/programs/claude-code.nix
@@ -1,7 +1,5 @@
 { inputs, ... }:
 {
-  home.file.".claude/skills/git-town" = {
-    source = "${inputs.claude-skills-bendrucker}/plugins/git-town/skills/git-town";
-    recursive = true;
-  };
+  home.file.".claude/skills/git-town".source =
+    "${inputs.claude-skills-bendrucker}/plugins/git-town/skills/git-town";
 }


### PR DESCRIPTION
## Summary
- Follows up on #6 — `recursive = true` still created a directory symlink
- Now uses `builtins.readDir` to dynamically create individual `home.file` entries per file
- Results in a real directory (`~/.claude/skills/git-town/`) with individual file symlinks inside
- Automatically picks up new files if the upstream skill adds them

## Test plan
- [ ] `ls -la ~/.claude/skills/git-town/` shows a real directory (not a symlink)
- [ ] `ls -la ~/.claude/skills/git-town/SKILL.md` shows a symlink to nix store
- [ ] `/skills` in Claude Code lists `git-town`

🤖 Generated with [Claude Code](https://claude.com/claude-code)