### PR TITLE
fix(television): use $EDITOR instead of bash-only ${EDITOR:-vim}

### DIFF
--- a/home-manager/programs/television.nix
+++ b/home-manager/programs/television.nix
@@ -26,8 +26,7 @@ in
         };
         actions.edit = {
           description = "Opens the selected entries with the default editor";
-          command = "\${EDITOR:-vim} '{}'";
-          shell = "bash";
+          command = "$EDITOR '{}'";
           mode = "execute";
         };
         actions.goto_parent_dir = {
@@ -101,8 +100,7 @@ in
         keybindings.enter = "actions:edit";
         actions.edit = {
           description = "Open file in editor at line";
-          command = "\${EDITOR:-vim} '+{strip_ansi|split:\\::1}' '{strip_ansi|split:\\::0}'";
-          shell = "bash";
+          command = "$EDITOR '+{strip_ansi|split:\\::1}' '{strip_ansi|split:\\::0}'";
           mode = "execute";
         };
       };
@@ -140,8 +138,7 @@ in
         };
         actions.edit = {
           description = "Open the repository in editor";
-          command = "\${EDITOR:-vim} '{}'";
-          shell = "bash";
+          command = "$EDITOR '{}'";
           mode = "execute";
         };
       };


### PR DESCRIPTION
## Problem

Running `tv text` (or `tv files` / `tv git-repos`) and pressing enter to open a match in the editor fails under **fish** with:

```
fish: ${ is not a valid variable in fish.
${EDITOR:-vim} '+{strip_ansi|split:\::1}' '{strip_ansi|split:\::0}'
^
```

## Root cause

The `actions.edit` commands used bash parameter-expansion syntax `${EDITOR:-vim}` and relied on a per-action `shell = "bash"` field to run under bash. But **television 0.13.5 does not support the per-action `shell` field** — it's a newer-than-0.13.5 feature (it exists on `main` and in the unstable package, but the running `tv` binary on the profile is 0.13.5). The unsupported key is silently ignored, so the command runs in the user's login shell (fish), which can't parse `${...}`.

The global `shell` setting is also unavailable in 0.13.5 (only `[shell_integration]` exists there), so neither shell-override mechanism works.

## Fix

Replace `${EDITOR:-vim}` with bare `$EDITOR` (which fish parses fine; `$EDITOR` is set to `nvim`) and drop the ignored `shell = "bash"` lines. Applied to all three affected channels: `files`, `text`, `git-repos`.

Verified: handing the new command string to `fish -c` parses correctly and expands to `nvim +N <file>`; the old string reproduces the reported error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)