### PR TITLE
fix(television): make text channel enter print path for `vi (tv text)`

### DIFF
--- a/home-manager/programs/television.nix
+++ b/home-manager/programs/television.nix
@@ -97,7 +97,10 @@ in
           offset = "{strip_ansi|split:\\::1}";
         };
         ui.preview_panel.header = "{strip_ansi|split:\\::..2}";
-        keybindings.enter = "actions:edit";
+        # enter prints "filepath:line" to stdout (the `output` template) so the
+        # channel composes with shell command substitution, e.g. `vi (tv text)`.
+        # The in-tv editor action stays available on ctrl-e.
+        keybindings.ctrl-e = "actions:edit";
         actions.edit = {
           description = "Open file in editor at line";
           command = "$EDITOR '+{strip_ansi|split:\\::1}' '{strip_ansi|split:\\::0}'";


### PR DESCRIPTION
## Problem

`vi (tv text)` hangs after selecting a match. The `text` channel bound `enter = "actions:edit"`, so television opened the editor *internally* on Enter, then exited — leaving fish to run `vi` on tv's leftover stdout with no real argument, hanging.

## Root cause

The `text` channel (added in the April home-manager migration, copied from upstream `main`) ships `enter = "actions:edit"`. That makes `tv text` a self-contained "open in editor" command, which is incompatible with the shell-substitution pattern `vi (tv text)` where tv is expected to just *print* the selection.

## Fix

Drop the `enter` override so Enter falls back to the default behavior: print the channel's `output` template to stdout. The template is already `{strip_ansi|split:\::..2}` = `filepath:line`, which the user's nvim is configured to parse — so `vi (tv text)` opens the file at the matched line.

The in-tv editor action is preserved on `ctrl-e` for anyone who wants it.

## Verification

Tested live in a tmux pane with a patched cable dir: `tv text` → query `homeConfigurationFactory` → Enter printed `CLAUDE.md:53` to stdout and nvim opened `CLAUDE.md` at line 53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)